### PR TITLE
Update download_binutils.sh

### DIFF
--- a/build/download_binutils.sh
+++ b/build/download_binutils.sh
@@ -3,7 +3,7 @@
 # This script will download binutils into third_party/binutils and build it.
 
 # Do NOT CHANGE this, unless you know what you're doing
-BINUTILS_SNAPSHOT="binutils-2.24.tar.bz2"
+BINUTILS_SNAPSHOT="binutils-2.25.tar.bz2"
 
 
 THIS_DIR="$(dirname "${0}")"


### PR DESCRIPTION
binutils 2.24 causes a compilation error("**../bfd/bfd.h:304 error: right-hand operand of comma expression has no effect [-Werror=unused-value]**") with gcc 5.2.1 on ubuntu 15.10 while 2.25 does not have this problem.
It is not convenient to specify the gcc 4.7 or other older version with "gclient sync" or manually. Modifying the download_binutils.sh locally to replace 2.24 with 2.25 cannot solve the problem, either, because "gclient sync" always tries to pull this repository version.
